### PR TITLE
modify duplicate and sort processors to support latest kvfile features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ language: python
 python:
 - 3.6
 env:
+  matrix:
+  - TOXENV="py36-sqlite" DEPLOY=yes
+  - TOXENV="py36-plyvel" DEPLOY=no
   global:
-  - TOXENV="py${PYTHON_VERSION//./}"
   - LANG=en_US.UTF-8
 install:
+- '[ "${TOXENV}" != "py36-plyvel" ] || sudo apt-get install libleveldb-dev libleveldb1'
 - make install
 - pip install coveralls
 script:
@@ -21,5 +24,6 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    condition: $DEPLOY = yes
   password:
     secure: Mojt569YIek3QxOruiO2kgXfLqVauVSHpXFHau+JTqqXCFaKnBm5Jaz6KcFiJ1Na+Bu9LJmeris2Szx+FoYdv1qi78XIbG1Ep4vao+ymsOnpMK/EkWSQlYDi3OLvY16gNyInqVsJhqxDUsbT6oz6FToe54qPrumfLR0W/ZbNdPtOull0BUkrCyOQByemnjBoyTh88zpVP8ntB7x+k3LmPEOmSmUpQcPHU9MsgLMFw89uwf/gskqK6KaUqcG95u+0MGgnEq3JOxKAkgQ3d+1bEXiAxXocTXQr2Turr70x+eWeEJW+tr7B0JarINKyDhNFz1x5KIjXBkUaogl3k2Z0wGq8evqWOAa5vhKDkNpKw7N3bg9ZSNhxuNgotKU27kVzJxLZ/7nZNdWDdW5WHVB0S6gSWzBBm8mTKlEuofaNPbngi9gY8M+DJDlsep340q0O3f9NBHQSBJtTYPqhONb/fkJaoCxM/hBpL0kmp1f/V3LSeHyE5qiTqpStivgHyDz2Rl3GMnk3ve2JA8rOl06z0pwudb5ATzDqkZSpklrKG9gxIkRlEK02XlYw7zSAZtyNO6hrcHvn+8ytBOKb/AyuS+wGpPWTJT6aaQa7hE87OlAIjJrvldYho+pYOutEK60mJTiPW8XPQ6j0B2w4z0zob3cqiBz6jm8Q0mvKIA0Em1U=

--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -205,11 +205,11 @@ def set_Type(name, **options):
 Sort incoming data based on key.
 
 `sort_rows` accepts a list of resources and a key (as a Python format string on row fields).
-It will output the rows for each resource, sorted according to the key (in ascending order).
+It will output the rows for each resource, sorted according to the key (in ascending order by default).
 
 
 ```python
-def sort_rows(key, resources=None):
+def sort_rows(key, resources=None, reverse=False):
     pass
 ```
 
@@ -219,6 +219,7 @@ def sort_rows(key, resources=None):
   - A regular expression matching resource names
   - A list of resource names
   - `None` indicates operation should be done on all resources
+- `reverse` - Set to True to return results in descending order
 
 #### unpivot.py
 Unpivot a table - convert one row with multiple value columns to multiple rows with one value column

--- a/dataflows/processors/sort_rows.py
+++ b/dataflows/processors/sort_rows.py
@@ -11,22 +11,22 @@ class KeyCalc(object):
         return self.key_spec.format(**row)
 
 
-def _sorter(rows, key_calc):
+def _sorter(rows, key_calc, reverse, batch_size):
     db = KVFile()
-    for row_num, row in enumerate(rows):
-        key = key_calc(row) + "{:08x}".format(row_num)
-        db.set(key, row)
-    for _, value in db.items():
+    db.insert(((key_calc(row) + "{:08x}".format(row_num), row) for row_num, row in enumerate(rows)),
+              batch_size=batch_size)
+
+    for _, value in db.items(reverse=reverse):
         yield value
 
 
-def sort_rows(key, resources=None):
+def sort_rows(key, resources=None, reverse=False, batch_size=1000):
     matcher = ResourceMatcher(resources)
     key_calc = KeyCalc(key)
 
     def func(rows):
         if matcher.match(rows.res.name):
-            yield from _sorter(rows, key_calc)
+            yield from _sorter(rows, key_calc, reverse, batch_size)
         else:
             yield from rows
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -193,3 +193,24 @@ def test_duplicate():
     assert list(results[0]) == a
     assert list(results[1]) == a
 
+
+def test_duplicate_many_rows():
+    from dataflows import duplicate
+
+    f = Flow(
+        ({'a': i, 'b': i} for i in range(1000)),
+        duplicate(),
+    )
+
+    results, _, _ = f.results()
+    assert len(list(results[0])) == 1000
+    assert len(list(results[1])) == 1000
+
+    f = Flow(
+        ({'a': i, 'b': i} for i in range(10000)),
+        duplicate(batch_size=0),
+    )
+
+    results, _, _ = f.results()
+    assert len(list(results[0])) == 10000
+    assert len(list(results[1])) == 10000

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -175,6 +175,19 @@ def test_sort_rows():
     ]
 
 
+def test_sort_reverse_many_rows():
+    from dataflows import sort_rows
+
+    f = Flow(
+        ({'a': i, 'b': i%5} for i in range(1000)),
+        sort_rows(key='{b}{a}', reverse=True, batch_size=0),
+    )
+    results, _, _ = f.results()
+    results = results[0]
+    assert results[0:2] == [{'a': 999, 'b': 4}, {'a': 994, 'b': 4}]
+    assert results[998:1000] == [{'a': 100, 'b': 0}, {'a': 0, 'b': 0}]
+
+
 def test_duplicate():
     from dataflows import duplicate
     
@@ -203,8 +216,8 @@ def test_duplicate_many_rows():
     )
 
     results, _, _ = f.results()
-    assert len(list(results[0])) == 1000
-    assert len(list(results[1])) == 1000
+    assert len(results[0]) == 1000
+    assert len(results[1]) == 1000
 
     f = Flow(
         ({'a': i, 'b': i} for i in range(10000)),
@@ -212,5 +225,5 @@ def test_duplicate_many_rows():
     )
 
     results, _, _ = f.results()
-    assert len(list(results[0])) == 10000
-    assert len(list(results[1])) == 10000
+    assert len(results[0]) == 10000
+    assert len(results[1]) == 10000

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ passenv=
   TRAVIS_JOB_ID
   TRAVIS_BRANCH
 commands=
-  pip install -U https://github.com/OriHoch/kvfile/archive/bulk-insert.zip
   py.test -s \
     --cov {[tox]package} \
     --cov-config tox.ini \

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 package=dataflows
 skip_missing_interpreters=true
 envlist=
-  py36
+  py36-{sqlite,plyvel}
 
 [testenv]
 deps=
@@ -10,12 +10,14 @@ deps=
   pytest
   pytest-cov
   coverage
+  py36-plyvel: plyvel
 passenv=
   CI
   TRAVIS
   TRAVIS_JOB_ID
   TRAVIS_BRANCH
 commands=
+  pip install -U https://github.com/OriHoch/kvfile/archive/bulk-insert.zip
   py.test -s \
     --cov {[tox]package} \
     --cov-config tox.ini \


### PR DESCRIPTION
Latest kvfile release contains the following features:
* bulk insert (Significantly reduces speed difference between LevelDB and Sqlite)
* reverse sort order

This PR integrates those changes to the `duplicate` and `sort_rows` processors

Added tests and modified tox to test with LevelDB and Sqlite

tox.ini installs kvfile from my modified branch, once bulk insert is merged - should remove that