### PR TITLE
minor fixes for Tutorial notebook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install list lint release test version
+.PHONY: all install list lint release test version notebooks
 
 
 PACKAGE := $(shell grep '^PACKAGE =' setup.py | cut -d "'" -f2)
@@ -26,3 +26,6 @@ test:
 
 version:
 	@echo $(VERSION)
+
+notebooks:
+	jupyter nbconvert *.ipynb --to markdown

--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ Type "help", "copyright", "credits" or "license" for more information.
 
 ## Learn more
 
-Dive into the [Tutorial](TUTORIAL.ipynb) to get a deeper glimpse into everything that `dataflows` can do.
+Dive into the [Tutorial](TUTORIAL.md) to get a deeper glimpse into everything that `dataflows` can do.
 Also review this list of [Built-in Processors](PROCESSORS.md), which also includes an API reference for each one of them.

--- a/TUTORIAL.ipynb
+++ b/TUTORIAL.ipynb
@@ -206,7 +206,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6ea98b940>, {})"
+       "(<datapackage.package.Package at 0x7fe9c68949e8>, {})"
       ]
      },
      "execution_count": 4,
@@ -299,7 +299,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6ea88fa58>, {})"
+       "(<datapackage.package.Package at 0x7fe9c67cd470>, {})"
       ]
      },
      "execution_count": 5,
@@ -339,7 +339,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6eb21cdd8>,\n",
+       "(<datapackage.package.Package at 0x7fe9c72c0400>,\n",
        " {'count_of_rows': 240,\n",
        "  'bytes': 5289,\n",
        "  'hash': '3bbfa40f5d22287e82da40dc6d7581a2',\n",
@@ -472,7 +472,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6ea983550>,\n",
+       "(<datapackage.package.Package at 0x7fe9c67eac18>,\n",
        " {'count_of_rows': 6,\n",
        "  'bytes': 744,\n",
        "  'hash': '1f0df7ed401ccff9f6c1674e98c62467',\n",
@@ -573,7 +573,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6ea518f60>,\n",
+       "(<datapackage.package.Package at 0x7fe9c64d7fd0>,\n",
        " {'count_of_rows': 4,\n",
        "  'bytes': 896,\n",
        "  'hash': 'ae319bad0ad1e345a2a86d8dc9de8375',\n",
@@ -667,7 +667,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6ea4806d8>,\n",
+       "(<datapackage.package.Package at 0x7fe9c63ba438>,\n",
        " {'count_of_rows': 4,\n",
        "  'bytes': 896,\n",
        "  'hash': 'ae319bad0ad1e345a2a86d8dc9de8375',\n",
@@ -775,7 +775,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6ea4040f0>,\n",
+       "(<datapackage.package.Package at 0x7fe9c6543160>,\n",
        " {'count_of_rows': 98,\n",
        "  'bytes': 6921,\n",
        "  'hash': '902088336aa4aa4fbab33446a241b5de',\n",
@@ -883,7 +883,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6e9edbfd0>,\n",
+       "(<datapackage.package.Package at 0x7fe9c5ea2860>,\n",
        " {'count_of_rows': 98,\n",
        "  'bytes': 6921,\n",
        "  'hash': '902088336aa4aa4fbab33446a241b5de',\n",
@@ -976,7 +976,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc6ea3fdeb8>, {})"
+       "(<datapackage.package.Package at 0x7fe9c5d96e48>, {})"
       ]
      },
      "execution_count": 14,

--- a/TUTORIAL.ipynb
+++ b/TUTORIAL.ipynb
@@ -22,7 +22,7 @@
     "Open a terminal with Miniconda (or Anaconda) and run the following to create a environment:\n",
     "\n",
     "```sh\n",
-    "conda create -n dataflows jupyter jupyterlab ipython leveldb\n",
+    "conda create -n dataflows 'python>=3.7' jupyter jupyterlab ipython leveldb\n",
     "```\n",
     "\n",
     "Activate the environment and install dataflows:\n",
@@ -161,7 +161,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [
     {
      "data": {
@@ -181,39 +183,14 @@
        "<table>\n",
        "<thead>\n",
        "<tr><th>#  </th><th>name\n",
-       "(string)                                 </th><th>population\n",
+       "(string)                 </th><th>population\n",
        "(string)              </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>1  </td><td>China                           </td><td>1,394,640,000</td></tr>\n",
-       "<tr><td>2  </td><td>India                           </td><td>1,338,310,000</td></tr>\n",
-       "<tr><td>3  </td><td>United States                   </td><td>328,009,000  </td></tr>\n",
-       "<tr><td>4  </td><td>Indonesia                       </td><td>265,015,300  </td></tr>\n",
-       "<tr><td>5  </td><td>Brazil                          </td><td>209,720,000  </td></tr>\n",
-       "<tr><td>6  </td><td>Pakistan                        </td><td>202,345,000  </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td>             </td></tr>\n",
-       "<tr><td>8  </td><td>Bangladesh                      </td><td>165,368,000  </td></tr>\n",
-       "<tr><td>9  </td><td>Russia                          </td><td>146,877,088  </td></tr>\n",
-       "<tr><td>10 </td><td>Japan                           </td><td>126,420,000  </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td>             </td></tr>\n",
-       "<tr><td>16 </td><td>Democratic Republic of the Congo</td><td>84,004,989   </td></tr>\n",
-       "<tr><td>17 </td><td>Germany                         </td><td>82,793,800   </td></tr>\n",
-       "<tr><td>18 </td><td>Iran                            </td><td>81,874,200   </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td>             </td></tr>\n",
-       "<tr><td>32 </td><td>Algeria                         </td><td>42,545,964   </td></tr>\n",
-       "<tr><td>33 </td><td>Ukraine                         </td><td>42,248,129   </td></tr>\n",
-       "<tr><td>34 </td><td>Sudan                           </td><td>40,909,450   </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td>             </td></tr>\n",
-       "<tr><td>64 </td><td>Malawi                          </td><td>17,931,637   </td></tr>\n",
-       "<tr><td>65 </td><td>Chile                           </td><td>17,574,003   </td></tr>\n",
-       "<tr><td>66 </td><td>Guatemala                       </td><td>17,302,084   </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td>             </td></tr>\n",
-       "<tr><td>128</td><td>Kuwait                          </td><td>4,226,920    </td></tr>\n",
-       "<tr><td>129</td><td>Panama                          </td><td>4,158,783    </td></tr>\n",
-       "<tr><td>130</td><td>Croatia                         </td><td>4,105,493    </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td>             </td></tr>\n",
-       "<tr><td>239</td><td>Cocos (Keeling) Islands         </td><td>544          </td></tr>\n",
-       "<tr><td>240</td><td>Pitcairn Islands                </td><td>50           </td></tr>\n",
+       "<tr><td>1  </td><td>China           </td><td>1,394,640,000</td></tr>\n",
+       "<tr><td>2  </td><td>India           </td><td>1,338,310,000</td></tr>\n",
+       "<tr><td>...</td><td>                </td><td>             </td></tr>\n",
+       "<tr><td>240</td><td>Pitcairn Islands</td><td>50           </td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
@@ -227,7 +204,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09e544978>, {})"
+       "(<datapackage.package.Package at 0x7fc6ea98b940>, {})"
       ]
      },
      "execution_count": 4,
@@ -263,7 +240,7 @@
     "\n",
     "Flow(\n",
     "      country_population(),\n",
-    "      printer(num_rows=2, tablefmt='html')\n",
+    "      printer(num_rows=1, tablefmt='html')\n",
     ").process()"
    ]
   },
@@ -299,39 +276,14 @@
        "<table>\n",
        "<thead>\n",
        "<tr><th>#  </th><th>name\n",
-       "(string)                                 </th><th style=\"text-align: right;\">            population\n",
+       "(string)                 </th><th style=\"text-align: right;\">         population\n",
        "(number)</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>1  </td><td>China                           </td><td style=\"text-align: right;\">1394.64    </td></tr>\n",
-       "<tr><td>2  </td><td>India                           </td><td style=\"text-align: right;\">1338.31    </td></tr>\n",
-       "<tr><td>3  </td><td>United States                   </td><td style=\"text-align: right;\"> 328.009   </td></tr>\n",
-       "<tr><td>4  </td><td>Indonesia                       </td><td style=\"text-align: right;\"> 265.015   </td></tr>\n",
-       "<tr><td>5  </td><td>Brazil                          </td><td style=\"text-align: right;\"> 209.72    </td></tr>\n",
-       "<tr><td>6  </td><td>Pakistan                        </td><td style=\"text-align: right;\"> 202.345   </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td style=\"text-align: right;\">           </td></tr>\n",
-       "<tr><td>8  </td><td>Bangladesh                      </td><td style=\"text-align: right;\"> 165.368   </td></tr>\n",
-       "<tr><td>9  </td><td>Russia                          </td><td style=\"text-align: right;\"> 146.877   </td></tr>\n",
-       "<tr><td>10 </td><td>Japan                           </td><td style=\"text-align: right;\"> 126.42    </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td style=\"text-align: right;\">           </td></tr>\n",
-       "<tr><td>16 </td><td>Democratic Republic of the Congo</td><td style=\"text-align: right;\">  84.005   </td></tr>\n",
-       "<tr><td>17 </td><td>Germany                         </td><td style=\"text-align: right;\">  82.7938  </td></tr>\n",
-       "<tr><td>18 </td><td>Iran                            </td><td style=\"text-align: right;\">  81.8742  </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td style=\"text-align: right;\">           </td></tr>\n",
-       "<tr><td>32 </td><td>Algeria                         </td><td style=\"text-align: right;\">  42.546   </td></tr>\n",
-       "<tr><td>33 </td><td>Ukraine                         </td><td style=\"text-align: right;\">  42.2481  </td></tr>\n",
-       "<tr><td>34 </td><td>Sudan                           </td><td style=\"text-align: right;\">  40.9094  </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td style=\"text-align: right;\">           </td></tr>\n",
-       "<tr><td>64 </td><td>Malawi                          </td><td style=\"text-align: right;\">  17.9316  </td></tr>\n",
-       "<tr><td>65 </td><td>Chile                           </td><td style=\"text-align: right;\">  17.574   </td></tr>\n",
-       "<tr><td>66 </td><td>Guatemala                       </td><td style=\"text-align: right;\">  17.3021  </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td style=\"text-align: right;\">           </td></tr>\n",
-       "<tr><td>128</td><td>Kuwait                          </td><td style=\"text-align: right;\">   4.22692 </td></tr>\n",
-       "<tr><td>129</td><td>Panama                          </td><td style=\"text-align: right;\">   4.15878 </td></tr>\n",
-       "<tr><td>130</td><td>Croatia                         </td><td style=\"text-align: right;\">   4.10549 </td></tr>\n",
-       "<tr><td>...</td><td>                                </td><td style=\"text-align: right;\">           </td></tr>\n",
-       "<tr><td>239</td><td>Cocos (Keeling) Islands         </td><td style=\"text-align: right;\">   0.000544</td></tr>\n",
-       "<tr><td>240</td><td>Pitcairn Islands                </td><td style=\"text-align: right;\">   5e-05   </td></tr>\n",
+       "<tr><td>1  </td><td>China           </td><td style=\"text-align: right;\">1394.64 </td></tr>\n",
+       "<tr><td>2  </td><td>India           </td><td style=\"text-align: right;\">1338.31 </td></tr>\n",
+       "<tr><td>...</td><td>                </td><td style=\"text-align: right;\">        </td></tr>\n",
+       "<tr><td>240</td><td>Pitcairn Islands</td><td style=\"text-align: right;\">   5e-05</td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
@@ -345,7 +297,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09e4da6a0>, {})"
+       "(<datapackage.package.Package at 0x7fc6ea88fa58>, {})"
       ]
      },
      "execution_count": 5,
@@ -360,7 +312,7 @@
     "\tcountry_population(),\n",
     "    set_type('population', type='number', groupChar=','),\n",
     "    lambda row: dict(row, population=row['population']/1000000),\n",
-    "    printer(num_rows=2, tablefmt='html')\n",
+    "    printer(num_rows=1, tablefmt='html')\n",
     ").process()"
    ]
   },
@@ -385,7 +337,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09efd1160>,\n",
+       "(<datapackage.package.Package at 0x7fc6eb21cdd8>,\n",
        " {'count_of_rows': 240,\n",
        "  'bytes': 5289,\n",
        "  'hash': '3bbfa40f5d22287e82da40dc6d7581a2',\n",
@@ -495,18 +447,16 @@
       "text/html": [
        "<table>\n",
        "<thead>\n",
-       "<tr><th style=\"text-align: right;\">  #</th><th style=\"text-align: right;\">   a\n",
+       "<tr><th>#  </th><th style=\"text-align: right;\">   a\n",
        "(integer)</th><th style=\"text-align: right;\">   b\n",
        "(integer)</th><th style=\"text-align: right;\">   c\n",
        "(integer)</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td style=\"text-align: right;\">  1</td><td style=\"text-align: right;\"> 3</td><td style=\"text-align: right;\"> 4</td><td style=\"text-align: right;\"> 5</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  2</td><td style=\"text-align: right;\"> 5</td><td style=\"text-align: right;\">12</td><td style=\"text-align: right;\">13</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  3</td><td style=\"text-align: right;\"> 6</td><td style=\"text-align: right;\"> 8</td><td style=\"text-align: right;\">10</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  4</td><td style=\"text-align: right;\"> 8</td><td style=\"text-align: right;\">15</td><td style=\"text-align: right;\">17</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  5</td><td style=\"text-align: right;\"> 9</td><td style=\"text-align: right;\">12</td><td style=\"text-align: right;\">15</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  6</td><td style=\"text-align: right;\">12</td><td style=\"text-align: right;\">16</td><td style=\"text-align: right;\">20</td></tr>\n",
+       "<tr><td>1  </td><td style=\"text-align: right;\"> 3</td><td style=\"text-align: right;\"> 4</td><td style=\"text-align: right;\"> 5</td></tr>\n",
+       "<tr><td>2  </td><td style=\"text-align: right;\"> 5</td><td style=\"text-align: right;\">12</td><td style=\"text-align: right;\">13</td></tr>\n",
+       "<tr><td>...</td><td style=\"text-align: right;\">  </td><td style=\"text-align: right;\">  </td><td style=\"text-align: right;\">  </td></tr>\n",
+       "<tr><td>6  </td><td style=\"text-align: right;\">12</td><td style=\"text-align: right;\">16</td><td style=\"text-align: right;\">20</td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
@@ -520,7 +470,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09e3340b8>,\n",
+       "(<datapackage.package.Package at 0x7fc6ea983550>,\n",
        " {'count_of_rows': 6,\n",
        "  'bytes': 744,\n",
        "  'hash': '1f0df7ed401ccff9f6c1674e98c62467',\n",
@@ -555,7 +505,7 @@
     "    set_type('c', type='integer'),\n",
     "    filter_pythagorean_triplets,\n",
     "    dump_to_path('pythagorean_triplets'),\n",
-    "    printer(tablefmt='html')\n",
+    "    printer(num_rows=1, tablefmt='html')\n",
     ").process()"
    ]
   },
@@ -598,16 +548,16 @@
       "text/html": [
        "<table>\n",
        "<thead>\n",
-       "<tr><th style=\"text-align: right;\">  #</th><th>name\n",
-       "(string)       </th><th>instrument\n",
+       "<tr><th>#  </th><th>name\n",
+       "(string)      </th><th>instrument\n",
        "(string)       </th><th>is_guitarist\n",
        "(boolean)      </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td style=\"text-align: right;\">  1</td><td>john  </td><td>guitar</td><td>True </td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  2</td><td>paul  </td><td>bass  </td><td>False</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  3</td><td>george</td><td>guitar</td><td>True </td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  4</td><td>ringo </td><td>drums </td><td>False</td></tr>\n",
+       "<tr><td>1  </td><td>john </td><td>guitar</td><td>True </td></tr>\n",
+       "<tr><td>2  </td><td>paul </td><td>bass  </td><td>False</td></tr>\n",
+       "<tr><td>...</td><td>     </td><td>      </td><td>     </td></tr>\n",
+       "<tr><td>4  </td><td>ringo</td><td>drums </td><td>False</td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
@@ -621,7 +571,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09e11de10>,\n",
+       "(<datapackage.package.Package at 0x7fc6ea518f60>,\n",
        " {'count_of_rows': 4,\n",
        "  'bytes': 896,\n",
        "  'hash': 'ae319bad0ad1e345a2a86d8dc9de8375',\n",
@@ -657,7 +607,7 @@
     "    add_is_guitarist_column_to_schema,\n",
     "    add_is_guitarist_column,\n",
     "    dump_to_path('beatles_guitarists'),\n",
-    "    printer(tablefmt='html')\n",
+    "    printer(num_rows=1, tablefmt='html')\n",
     ").process()"
    ]
   },
@@ -692,16 +642,16 @@
       "text/html": [
        "<table>\n",
        "<thead>\n",
-       "<tr><th style=\"text-align: right;\">  #</th><th>name\n",
-       "(string)       </th><th>instrument\n",
+       "<tr><th>#  </th><th>name\n",
+       "(string)      </th><th>instrument\n",
        "(string)       </th><th>is_guitarist\n",
        "(boolean)      </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td style=\"text-align: right;\">  1</td><td>john  </td><td>guitar</td><td>True </td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  2</td><td>paul  </td><td>bass  </td><td>False</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  3</td><td>george</td><td>guitar</td><td>True </td></tr>\n",
-       "<tr><td style=\"text-align: right;\">  4</td><td>ringo </td><td>drums </td><td>False</td></tr>\n",
+       "<tr><td>1  </td><td>john </td><td>guitar</td><td>True </td></tr>\n",
+       "<tr><td>2  </td><td>paul </td><td>bass  </td><td>False</td></tr>\n",
+       "<tr><td>...</td><td>     </td><td>      </td><td>     </td></tr>\n",
+       "<tr><td>4  </td><td>ringo</td><td>drums </td><td>False</td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
@@ -715,7 +665,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09dfae5f8>,\n",
+       "(<datapackage.package.Package at 0x7fc6ea4806d8>,\n",
        " {'count_of_rows': 4,\n",
        "  'bytes': 896,\n",
        "  'hash': 'ae319bad0ad1e345a2a86d8dc9de8375',\n",
@@ -758,7 +708,7 @@
     "    load('beatles.csv'),\n",
     "    add_is_guitarist_column,\n",
     "    dump_to_path('beatles_guitarists'),\n",
-    "    printer(tablefmt='html')\n",
+    "    printer(num_rows=1, tablefmt='html')\n",
     ").process()"
    ]
   },
@@ -780,13 +730,6 @@
    "execution_count": 12,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "using cache data from .cache/emmy\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -830,7 +773,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09dde6a58>,\n",
+       "(<datapackage.package.Package at 0x7fc6ea4040f0>,\n",
        " {'count_of_rows': 98,\n",
        "  'bytes': 6921,\n",
        "  'hash': '902088336aa4aa4fbab33446a241b5de',\n",
@@ -843,7 +786,7 @@
     }
    ],
    "source": [
-    "from dataflows import Flow, load, dump_to_path, cache\n",
+    "from dataflows import Flow, load, dump_to_path\n",
     "\n",
     "def find_double_winners(package):\n",
     "\n",
@@ -873,13 +816,10 @@
     "                 academy)\n",
     "\n",
     "Flow(\n",
-    "    cache(\n",
-    "        # Emmy award nominees and winners\n",
-    "        load('https://raw.githubusercontent.com/datahq/dataflows/master/data/emmy.csv', name='emmies'),\n",
-    "        # Academy award nominees and winners\n",
-    "        load('https://raw.githubusercontent.com/datahq/dataflows/master/data/academy.csv', encoding='utf8', name='oscars'),\n",
-    "        cache_path='.cache/emmy'\n",
-    "    ),\n",
+    "    # Emmy award nominees and winners\n",
+    "    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/emmy.csv', name='emmies'),\n",
+    "    # Academy award nominees and winners\n",
+    "    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/academy.csv', encoding='utf8', name='oscars'),\n",
     "    find_double_winners,\n",
     "    dump_to_path('double_winners'),\n",
     "    printer(num_rows=1, tablefmt='html')\n",
@@ -890,8 +830,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we used the cache processor, it keeps a cache in the given `cache_path` and loads from cache if it exists. This will come in handy in the next script where we reuse this data.\n",
-    "\n",
     "Previous flow was a bit complicated, but luckily we have the `join`, `concatenate` and `filter_rows` processors which make such combinations a snap"
    ]
   },
@@ -900,13 +838,6 @@
    "execution_count": 13,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "using cache data from .cache/emmy\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -950,7 +881,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09daba0b8>,\n",
+       "(<datapackage.package.Package at 0x7fc6e9edbfd0>,\n",
        " {'count_of_rows': 98,\n",
        "  'bytes': 6921,\n",
        "  'hash': '902088336aa4aa4fbab33446a241b5de',\n",
@@ -963,10 +894,13 @@
     }
    ],
    "source": [
-    "from dataflows import Flow, load, dump_to_path, join, concatenate, filter_rows, cache, printer\n",
+    "from dataflows import Flow, load, dump_to_path, join, concatenate, filter_rows, printer\n",
     "\n",
     "Flow(\n",
-    "    cache(cache_path='.cache/emmy'),\n",
+    "    # Emmy award nominees and winners\n",
+    "    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/emmy.csv', name='emmies'),\n",
+    "    # Academy award nominees and winners\n",
+    "    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/academy.csv', encoding='utf8', name='oscars'),\n",
     "    filter_rows(equals=[dict(winner=1)], resources=['emmies']),\n",
     "    concatenate(\n",
     "        dict(emmy_nominee=['nominee'],),\n",
@@ -1040,7 +974,7 @@
     {
      "data": {
       "text/plain": [
-       "(<datapackage.package.Package at 0x7fc09d982400>, {})"
+       "(<datapackage.package.Package at 0x7fc6ea3fdeb8>, {})"
       ]
      },
      "execution_count": 14,

--- a/TUTORIAL.ipynb
+++ b/TUTORIAL.ipynb
@@ -8,6 +8,8 @@
     "\n",
     "This tutorial is built as a Jupyter notebook which allows you to run and modify the code inline and can be used as a starting point for new Dataflows projects.\n",
     "\n",
+    "To get started quickly without any installation, click here: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/datahq/dataflows/master?filepath=TUTORIAL.ipynb)\n",
+    "\n",
     "If you want, you can just skip the installation section and follow the tutorial as-is, copy-pasting the relevant code example to your Python interpreter.\n"
    ]
   },

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,1 +1,694 @@
-The tutorial moved to: https://github.com/datahq/dataflows/blob/master/TUTORIAL.ipynb
+
+# Dataflows Tutorial
+
+This tutorial is built as a Jupyter notebook which allows you to run and modify the code inline and can be used as a starting point for new Dataflows projects.
+
+To get started quickly without any installation, click here: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/datahq/dataflows/master?filepath=TUTORIAL.ipynb)
+
+If you want, you can just skip the installation section and follow the tutorial as-is, copy-pasting the relevant code example to your Python interpreter.
+
+
+## Installation
+
+Easiest way to get started on any OS is to [Download and install the latest Python 3.7 Miniconda distribution](https://conda.io/miniconda.html)
+
+Open a terminal with Miniconda (or Anaconda) and run the following to create a environment:
+
+```sh
+conda create -n dataflows 'python>=3.7' jupyter jupyterlab ipython leveldb
+```
+
+Activate the environment and install dataflows:
+
+```sh
+. activate dataflows
+pip install -U dataflows[speedup]
+```
+
+The above command installs Dataflows optimized for speed, if you encounter problems installing it, install without the `[speedup]` suffix.
+
+Save the tutorial notebook in current working directory (right-click and save on following link): https://raw.githubusercontent.com/datahq/dataflows/master/TUTORIAL.ipynb
+
+Start Jupyter Lab:
+
+```sh
+jupyter lab
+```
+
+Double-click the tutorial notebook you downloaded from the sidebar of Jupyter Lab
+
+## Learn how to write your own processing flows
+
+Let's start with the traditional 'hello, world' example:
+
+
+```python
+from dataflows import Flow
+
+data = [
+  {'data': 'Hello'},
+  {'data': 'World'}
+]
+
+def lowerData(row):
+    row['data'] = row['data'].lower()
+
+Flow(
+      data,
+      lowerData
+).results()[0]
+```
+
+
+
+
+    [[{'data': 'hello'}, {'data': 'world'}]]
+
+
+
+This very simple flow takes a list of `dict`s and applies a row processing function on each one of them.
+
+We can load data from a file instead:
+
+
+```python
+%%writefile beatles.csv
+name,instrument 
+john,guitar
+paul,bass
+george,guitar
+ringo,drums
+```
+
+    Overwriting beatles.csv
+
+
+
+```python
+from dataflows import Flow, load
+
+def titleName(row):
+    row['name'] = row['name'].title()
+
+Flow(
+      load('beatles.csv'),
+      titleName
+).results()[0]
+```
+
+
+
+
+    [[{'name': 'John', 'instrument': 'guitar'},
+      {'name': 'Paul', 'instrument': 'bass'},
+      {'name': 'George', 'instrument': 'guitar'},
+      {'name': 'Ringo', 'instrument': 'drums'}]]
+
+
+
+The source file can be a CSV file, an Excel file or a Json file. You can use a local file name or a URL for a file hosted somewhere on the web.
+
+Data sources can be generators and not just lists or files. Let's take as an example a very simple scraper:
+
+
+```python
+from dataflows import Flow, printer
+
+from xml.etree import ElementTree
+from urllib.request import urlopen
+
+# Get from Wikipedia the population count for each country
+def country_population():
+    # Read the Wikipedia page and parse it using etree
+    page = urlopen('https://en.wikipedia.org/wiki/List_of_countries_and_dependencies_by_population').read()
+    tree = ElementTree.fromstring(page)
+    # Iterate on all tables, rows and cells
+    for table in tree.findall('.//table'):
+        if 'wikitable' in table.attrib.get('class', ''):
+            for row in table.find('tbody').findall('tr'):
+                cells = row.findall('td')
+                if len(cells) > 3:
+                    # If a matching row is found...
+                    name = cells[1].find('.//a').attrib.get('title')
+                    population = cells[2].text
+                    # ... yield a row with the information
+                    yield dict(
+                        name=name,
+                        population=population
+                    )
+
+Flow(
+      country_population(),
+      printer(num_rows=1, tablefmt='html')
+).process()
+```
+
+
+<h3>res_1</h3>
+
+
+
+<table>
+<thead>
+<tr><th>#  </th><th>name
+(string)                 </th><th>population
+(string)              </th></tr>
+</thead>
+<tbody>
+<tr><td>1  </td><td>China           </td><td>1,394,640,000</td></tr>
+<tr><td>2  </td><td>India           </td><td>1,338,310,000</td></tr>
+<tr><td>...</td><td>                </td><td>             </td></tr>
+<tr><td>240</td><td>Pitcairn Islands</td><td>50           </td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c68949e8>, {})
+
+
+
+This is nice, but we do prefer the numbers to be actual numbers and not strings.
+
+In order to do that, let's simply define their type to be numeric and truncate to millions:
+
+
+```python
+from dataflows import Flow, set_type
+
+Flow(
+	country_population(),
+    set_type('population', type='number', groupChar=','),
+    lambda row: dict(row, population=row['population']/1000000),
+    printer(num_rows=1, tablefmt='html')
+).process()
+```
+
+
+<h3>res_1</h3>
+
+
+
+<table>
+<thead>
+<tr><th>#  </th><th>name
+(string)                 </th><th style="text-align: right;">         population
+(number)</th></tr>
+</thead>
+<tbody>
+<tr><td>1  </td><td>China           </td><td style="text-align: right;">1394.64 </td></tr>
+<tr><td>2  </td><td>India           </td><td style="text-align: right;">1338.31 </td></tr>
+<tr><td>...</td><td>                </td><td style="text-align: right;">        </td></tr>
+<tr><td>240</td><td>Pitcairn Islands</td><td style="text-align: right;">   5e-05</td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c67cd470>, {})
+
+
+
+Data is automatically converted to the correct native Python type.
+
+Apart from data-types, it's also possible to set other constraints to the data. If the data fails validation (or does not fit the assigned data-type) an exception will be thrown - making this method highly effective for validating data and ensuring data quality. 
+
+What about large data files? In the above examples, the results are loaded into memory, which is not always preferrable or acceptable. In many cases, we'd like to store the results directly onto a hard drive - without having the machine's RAM limit in any way the amount of data we can process.
+
+We do it by using _dump_ processors:
+
+
+```python
+from dataflows import Flow, set_type, dump_to_path
+
+Flow(
+    country_population(),
+    set_type('population', type='number', groupChar=','),
+    dump_to_path('country_population')
+).process()
+```
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c72c0400>,
+     {'count_of_rows': 240,
+      'bytes': 5289,
+      'hash': '3bbfa40f5d22287e82da40dc6d7581a2',
+      'dataset_name': None})
+
+
+
+Running this code will create a local directory called `county_population`, containing two files:
+
+
+```python
+import glob
+print("\n".join(glob.glob('country_population/*')))
+```
+
+    country_population/res_1.csv
+    country_population/datapackage.json
+
+
+The CSV file - `res_1.csv` - is where the data is stored. The `datapackage.json` file is a metadata file, holding information about the data, including its schema.
+
+We can now open the CSV file with any spreadsheet program or code library supporting the CSV format - or using one of the **data package** libraries out there, like so:
+
+
+```python
+from datapackage import Package
+pkg = Package('country_population/datapackage.json')
+it = pkg.resources[0].iter(keyed=True)
+print(next(it))
+```
+
+    {'name': 'China', 'population': Decimal('1394640000')}
+
+
+Note how using the data package meta-data, data-types are restored and there's no need to 're-parse' the data. This also works with other types too, such as dates, booleans and even `list`s and `dict`s.
+
+So far we've seen how to load data, process it row by row, and then inspect the results or store them in a data package.
+
+Let's see how we can do more complex processing by manipulating the entire data stream:
+
+
+```python
+from dataflows import Flow, set_type, dump_to_path, printer
+
+# Generate all triplets (a,b,c) so that 1 <= a <= b < c <= 20
+def all_triplets():
+    for a in range(1, 20):
+        for b in range(a, 20):
+            for c in range(b+1, 21):
+                yield dict(a=a, b=b, c=c)
+
+# Yield row only if a^2 + b^2 == c^1
+def filter_pythagorean_triplets(rows):
+    for row in rows:
+        if row['a']**2 + row['b']**2 == row['c']**2:
+            yield row
+
+Flow(
+    all_triplets(),
+    set_type('a', type='integer'),
+    set_type('b', type='integer'),
+    set_type('c', type='integer'),
+    filter_pythagorean_triplets,
+    dump_to_path('pythagorean_triplets'),
+    printer(num_rows=1, tablefmt='html')
+).process()
+```
+
+
+<h3>res_1</h3>
+
+
+
+<table>
+<thead>
+<tr><th>#  </th><th style="text-align: right;">   a
+(integer)</th><th style="text-align: right;">   b
+(integer)</th><th style="text-align: right;">   c
+(integer)</th></tr>
+</thead>
+<tbody>
+<tr><td>1  </td><td style="text-align: right;"> 3</td><td style="text-align: right;"> 4</td><td style="text-align: right;"> 5</td></tr>
+<tr><td>2  </td><td style="text-align: right;"> 5</td><td style="text-align: right;">12</td><td style="text-align: right;">13</td></tr>
+<tr><td>...</td><td style="text-align: right;">  </td><td style="text-align: right;">  </td><td style="text-align: right;">  </td></tr>
+<tr><td>6  </td><td style="text-align: right;">12</td><td style="text-align: right;">16</td><td style="text-align: right;">20</td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c67eac18>,
+     {'count_of_rows': 6,
+      'bytes': 744,
+      'hash': '1f0df7ed401ccff9f6c1674e98c62467',
+      'dataset_name': None})
+
+
+
+The `filter_pythagorean_triplets` function takes an iterator of rows, and yields only the ones that pass its condition. 
+
+The flow framework knows whether a function is meant to hande a single row or a row iterator based on its parameters: 
+
+- if it accepts a single `row` parameter, then it's a row processor.
+- if it accepts a single `rows` parameter, then it's a rows processor.
+- if it accepts a single `package` parameter, then it's a package processor.
+
+Let's see a few examples of what we can do with a package processors.
+
+First, let's add a field to the data:
+
+
+```python
+from dataflows import Flow, load, dump_to_path, printer
+
+
+def add_is_guitarist_column_to_schema(package):
+    # Add a new field to the first resource
+    package.pkg.descriptor['resources'][0]['schema']['fields'].append(dict(
+        name='is_guitarist',
+        type='boolean'
+    ))
+    # Must yield the modified datapackage
+    yield package.pkg
+    # And its resources
+    yield from package
+
+def add_is_guitarist_column(row):
+    row['is_guitarist'] = row['instrument'] == 'guitar'
+
+Flow(
+    # Same one as above
+    load('beatles.csv'),
+    add_is_guitarist_column_to_schema,
+    add_is_guitarist_column,
+    dump_to_path('beatles_guitarists'),
+    printer(num_rows=1, tablefmt='html')
+).process()
+```
+
+
+<h3>beatles</h3>
+
+
+
+<table>
+<thead>
+<tr><th>#  </th><th>name
+(string)      </th><th>instrument
+(string)       </th><th>is_guitarist
+(boolean)      </th></tr>
+</thead>
+<tbody>
+<tr><td>1  </td><td>john </td><td>guitar</td><td>True </td></tr>
+<tr><td>2  </td><td>paul </td><td>bass  </td><td>False</td></tr>
+<tr><td>...</td><td>     </td><td>      </td><td>     </td></tr>
+<tr><td>4  </td><td>ringo</td><td>drums </td><td>False</td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c64d7fd0>,
+     {'count_of_rows': 4,
+      'bytes': 896,
+      'hash': 'ae319bad0ad1e345a2a86d8dc9de8375',
+      'dataset_name': None})
+
+
+
+In this example we create two steps - one for adding the new field (`is_guitarist`) to the schema and another step to modify the actual data.
+
+We can combine the two into one step:
+
+
+```python
+from dataflows import Flow, load, dump_to_path
+
+
+def add_is_guitarist_column(package):
+
+    # Add a new field to the first resource
+    package.pkg.descriptor['resources'][0]['schema']['fields'].append(dict(
+        name='is_guitarist',
+        type='boolean'
+    ))
+    # Must yield the modified datapackage
+    yield package.pkg
+
+    # Now iterate on all resources
+    resources = iter(package)
+    # Take the first resource
+    beatles = next(resources)
+
+    # And yield it with with the modification
+    def f(row):
+        row['is_guitarist'] = row['instrument'] == 'guitar'
+        return row
+
+    yield map(f, beatles)
+
+Flow(
+    # Same one as above
+    load('beatles.csv'),
+    add_is_guitarist_column,
+    dump_to_path('beatles_guitarists'),
+    printer(num_rows=1, tablefmt='html')
+).process()
+```
+
+
+<h3>beatles</h3>
+
+
+
+<table>
+<thead>
+<tr><th>#  </th><th>name
+(string)      </th><th>instrument
+(string)       </th><th>is_guitarist
+(boolean)      </th></tr>
+</thead>
+<tbody>
+<tr><td>1  </td><td>john </td><td>guitar</td><td>True </td></tr>
+<tr><td>2  </td><td>paul </td><td>bass  </td><td>False</td></tr>
+<tr><td>...</td><td>     </td><td>      </td><td>     </td></tr>
+<tr><td>4  </td><td>ringo</td><td>drums </td><td>False</td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c63ba438>,
+     {'count_of_rows': 4,
+      'bytes': 896,
+      'hash': 'ae319bad0ad1e345a2a86d8dc9de8375',
+      'dataset_name': None})
+
+
+
+The contract for the `package` processing function is simple:
+
+First modify `package.pkg` (which is a `Package` instance) and yield it.
+
+Then, yield any resources that should exist on the output, with or without modifications.
+
+In the next example we're removing an entire resource in a package processor - this next one filters the list of Academy Award nominees to those who won both the Oscar and an Emmy award:
+
+
+```python
+from dataflows import Flow, load, dump_to_path
+
+def find_double_winners(package):
+
+    # Remove the emmies resource - 
+    #    we're going to consume it now
+    package.pkg.remove_resource('emmies')
+    # Must yield the modified datapackage
+    yield package.pkg
+
+    # Now iterate on all resources
+    resources = iter(package)
+
+    # Emmies is the first - 
+    # read all its data and create a set of winner names
+    emmy = next(resources)
+    emmy_winners = set(
+        map(lambda x: x['nominee'], 
+            filter(lambda x: x['winner'],
+                   emmy))
+    )
+
+    # Oscars are next - 
+    # filter rows based on the emmy winner set
+    academy = next(resources)
+    yield filter(lambda row: (row['Winner'] and 
+                              row['Name'] in emmy_winners),
+                 academy)
+
+Flow(
+    # Emmy award nominees and winners
+    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/emmy.csv', name='emmies'),
+    # Academy award nominees and winners
+    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/academy.csv', encoding='utf8', name='oscars'),
+    find_double_winners,
+    dump_to_path('double_winners'),
+    printer(num_rows=1, tablefmt='html')
+).process()
+```
+
+
+<h3>oscars</h3>
+
+
+
+<table>
+<thead>
+<tr><th>#  </th><th>Year
+(string)          </th><th style="text-align: right;">   Ceremony
+(integer)</th><th>Award
+(string)               </th><th style="text-align: right;">  Winner
+(string)</th><th>Name
+(string)                  </th><th>Film
+(string)                           </th></tr>
+</thead>
+<tbody>
+<tr><td>1  </td><td>1931/1932</td><td style="text-align: right;"> 5</td><td>Actress       </td><td style="text-align: right;">1</td><td>Helen Hayes      </td><td>The Sin of Madelon Claudet</td></tr>
+<tr><td>2  </td><td>1932/1933</td><td style="text-align: right;"> 6</td><td>Actress       </td><td style="text-align: right;">1</td><td>Katharine Hepburn</td><td>Morning Glory             </td></tr>
+<tr><td>...</td><td>         </td><td style="text-align: right;">  </td><td>              </td><td style="text-align: right;"> </td><td>                 </td><td>                          </td></tr>
+<tr><td>98 </td><td>2015     </td><td style="text-align: right;">88</td><td>Honorary Award</td><td style="text-align: right;">1</td><td>Gena Rowlands    </td><td>                          </td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c6543160>,
+     {'count_of_rows': 98,
+      'bytes': 6921,
+      'hash': '902088336aa4aa4fbab33446a241b5de',
+      'dataset_name': None})
+
+
+
+Previous flow was a bit complicated, but luckily we have the `join`, `concatenate` and `filter_rows` processors which make such combinations a snap
+
+
+```python
+from dataflows import Flow, load, dump_to_path, join, concatenate, filter_rows, printer
+
+Flow(
+    # Emmy award nominees and winners
+    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/emmy.csv', name='emmies'),
+    # Academy award nominees and winners
+    load('https://raw.githubusercontent.com/datahq/dataflows/master/data/academy.csv', encoding='utf8', name='oscars'),
+    filter_rows(equals=[dict(winner=1)], resources=['emmies']),
+    concatenate(
+        dict(emmy_nominee=['nominee'],),
+        dict(name='emmies_filtered'),
+        resources='emmies'
+    ),
+    join(
+        'emmies_filtered', ['emmy_nominee'],  # Source resource
+        'oscars', ['Name'],                   # Target resource
+        full=False   # Don't add new fields, remove unmatched rows
+    ),
+    filter_rows(equals=[dict(Winner='1')]),
+    dump_to_path('double_winners'),
+    printer(num_rows=1, tablefmt='html')
+).process()
+```
+
+
+<h3>oscars</h3>
+
+
+
+<table>
+<thead>
+<tr><th>#  </th><th>Year
+(string)          </th><th style="text-align: right;">   Ceremony
+(integer)</th><th>Award
+(string)               </th><th style="text-align: right;">  Winner
+(string)</th><th>Name
+(string)                  </th><th>Film
+(string)                           </th></tr>
+</thead>
+<tbody>
+<tr><td>1  </td><td>1931/1932</td><td style="text-align: right;"> 5</td><td>Actress       </td><td style="text-align: right;">1</td><td>Helen Hayes      </td><td>The Sin of Madelon Claudet</td></tr>
+<tr><td>2  </td><td>1932/1933</td><td style="text-align: right;"> 6</td><td>Actress       </td><td style="text-align: right;">1</td><td>Katharine Hepburn</td><td>Morning Glory             </td></tr>
+<tr><td>...</td><td>         </td><td style="text-align: right;">  </td><td>              </td><td style="text-align: right;"> </td><td>                 </td><td>                          </td></tr>
+<tr><td>98 </td><td>2015     </td><td style="text-align: right;">88</td><td>Honorary Award</td><td style="text-align: right;">1</td><td>Gena Rowlands    </td><td>                          </td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c5ea2860>,
+     {'count_of_rows': 98,
+      'bytes': 6921,
+      'hash': '902088336aa4aa4fbab33446a241b5de',
+      'dataset_name': None})
+
+
+
+## Builtin Processors
+
+DataFlows comes with a few built-in processors which do most of the heavy lifting in many common scenarios, leaving you to implement only the minimum code that is specific to your specific problem.
+
+A complete list, which also includes an API reference for each one of them, can be found in the [Built-in Processors](https://github.com/datahq/dataflows/blob/master/PROCESSORS.md#builtin-processors) page.
+
+## Nested Flows
+
+The flow object itself can be used as a step in another flow
+
+
+```python
+from dataflows import Flow, printer
+
+def upper(row):
+    for k in row:
+        row[k] = row[k].upper()
+
+def lower_first_letter(row):
+    for k in row:
+        row[k] = f'{row[k][0].lower()}{row[k][1:]}'
+
+text_processing_flow = Flow(
+    upper,
+    lower_first_letter
+)
+
+Flow(
+    [{'foo': 'bar'},
+     {'foo': 'bax'}], 
+    text_processing_flow,
+    printer(tablefmt='html')
+).process()
+```
+
+
+<h3>res_1</h3>
+
+
+
+<table>
+<thead>
+<tr><th style="text-align: right;">  #</th><th>foo
+(string)    </th></tr>
+</thead>
+<tbody>
+<tr><td style="text-align: right;">  1</td><td>bAR</td></tr>
+<tr><td style="text-align: right;">  2</td><td>bAX</td></tr>
+</tbody>
+</table>
+
+
+
+
+
+    (<datapackage.package.Package at 0x7fe9c5d96e48>, {})
+
+
+
+## Next Steps
+
+* [DataFlows Processors Reference](https://github.com/datahq/dataflows/blob/master/PROCESSORS.md)
+* [Datapackage Pipelines Tutorial](https://github.com/frictionlessdata/datapackage-pipelines/blob/master/TUTORIAL.ipynb) - Use the flows as building blocks for more complex pipelines processing systems.


### PR DESCRIPTION
* fixes and improvements to tutorial
* add option to launch on binder, click here to launch this PR branch: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/OriHoch/dataflows/jupyter-tutorial-fixes?filepath=TUTORIAL.ipynb)
* render notebook to markdown because GitHub notebook rendering is slow and broken
* add `notebooks` make target for rendering notebooks to markdown, to modify the notebooks, need to modify the ipynb file and then render to markdown