### PR TITLE
add use_titles option to csv format writer

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -126,6 +126,8 @@ def dump_to_path(out_path='.',
 
 - `pretty_descriptor` - Should the resulting descriptor be JSON pretty-formatted with indentation for readability, or as compact as possible (default `True`)
 
+- `use_titles` - If set to True, will use the field titles for header rows rather then field names (relevant for csv format only, default `False`)
+
 #### dump_to_zip
 Store the results in a valid datapackage, all files archived in one zipped file
 

--- a/dataflows/processors/dumpers/file_dumper.py
+++ b/dataflows/processors/dumpers/file_dumper.py
@@ -15,6 +15,7 @@ class FileDumper(DumperBase):
         super(FileDumper, self).__init__(options)
         self.force_format = options.get('force_format', True)
         self.forced_format = options.get('format', 'csv')
+        self.use_titles = options.get('use_titles', False)
 
     def process_datapackage(self, datapackage):
         datapackage = \
@@ -88,7 +89,8 @@ class FileDumper(DumperBase):
             schema = resource.res.schema
 
             temp_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)
-            writer = self.file_formatters[resource.res.name](temp_file, schema)
+            writer_kwargs = {'use_titles': True} if self.use_titles else {}
+            writer = self.file_formatters[resource.res.name](temp_file, schema, **writer_kwargs)
 
             return self.rows_processor(resource,
                                        writer,

--- a/dataflows/processors/dumpers/file_formats.py
+++ b/dataflows/processors/dumpers/file_formats.py
@@ -61,6 +61,16 @@ class FileFormat():
         self.write_transformed_row(transformed_row)
 
 
+class CsvTitlesDictWriter(csv.DictWriter):
+    def __init__(self, *args, **kwargs):
+        self.fieldtitles = kwargs.pop('fieldtitles')
+        super().__init__(*args, **kwargs)
+
+    def writeheader(self):
+        header = dict(zip(self.fieldnames, self.fieldtitles))
+        self.writerow(header)
+
+
 class CSVFormat(FileFormat):
 
     SERIALIZERS = {
@@ -94,9 +104,13 @@ class CSVFormat(FileFormat):
         },
     }
 
-    def __init__(self, file, schema):
+    def __init__(self, file, schema, use_titles=False):
         headers = [f.name for f in schema.fields]
-        csv_writer = csv.DictWriter(file, headers)
+        if use_titles:
+            titles = [f.descriptor.get('title', f.name) for f in schema.fields]
+            csv_writer = CsvTitlesDictWriter(file, headers, fieldtitles=titles)
+        else:
+            csv_writer = csv.DictWriter(file, headers)
         csv_writer.writeheader()
         super(CSVFormat, self).__init__(csv_writer, schema)
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -399,6 +399,7 @@ def test_update_resource():
     assert dp.descriptor['resources'][2]['source'] == 'thewild'
     assert dp.descriptor['resources'][4]['source'] == 'thewild'
 
+
 def test_set_type_resources():
     from dataflows import Flow, set_type, validate
 
@@ -416,4 +417,20 @@ def test_set_type_resources():
     assert results[0][1]['a'] == 1
     assert results[1][3]['b'] == 3
     assert results[2][8]['c'] == 8.0
-   
+
+
+def test_dump_to_path_use_titles():
+    from dataflows import Flow, dump_to_path, set_type
+    import tabulator
+
+    Flow(
+        [{'hello': 'world', 'hola': 'mundo'}, {'hello': 'עולם', 'hola': 'عالم'}],
+        *(set_type(name, resources=['res_1'], title=title) for name, title
+          in (('hello', 'שלום'), ('hola', 'aloha'))),
+        dump_to_path('data/dump_with_titles', use_titles=True)
+    ).process()
+
+    with tabulator.Stream('data/dump_with_titles/res_1.csv') as stream:
+        assert stream.read() == [['שלום',   'aloha'],
+                                 ['world',  'mundo'],
+                                 ['עולם',   'عالم']]


### PR DESCRIPTION
Allows to export a csv file using the field titles for the header row