### PR TITLE
[load][xs]: allow setting encoding

### DIFF
--- a/dataflows/processors/load.py
+++ b/dataflows/processors/load.py
@@ -47,6 +47,7 @@ class load(DataStreamProcessor):
                 descriptor = dict(path=self.load_source,
                                   profile='tabular-data-resource')
                 descriptor['format'] = self.options.get('format')
+                descriptor['encoding'] = self.options.get('encoding')
                 self.options.setdefault('ignore_blank_headers', True)
                 self.options.setdefault('headers', 1)
                 self.res = Resource(descriptor,


### PR DESCRIPTION
I have a source that datapackage cannot detect encoding for. And getting errors when trying run flows. PR allows setting encoding for resources if that is present in the descriptor

```
Flow(
load(
        load_source='https://www2.census.gov/programs-surveys/cps/tables/time-series/historical-income-households/h01ar.xls',
        format='xls',
        sheet= 1,
        # remove first 6 rows. remove rows that contain data from 1967 - last year and 3 rows after. Finaly last row
        skip_rows=list(range(1,62)) + [-1],
        encoding='utf-8',
        headers=['Year', 'Number (thousands)', 'Lowest', 'Second', 'Third', 'Fourth', 'Top 5 percent'],
    )
   printer()
).process()
```