### PR TITLE
printer: limit cell size

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -74,7 +74,7 @@ def printer(num_rows=10, last_rows=None, fields=None, resources=None,
 - `resources` - optional, allows to limit the printed resources, same semantics as `load` processor `resources` argument
 - `header_print` - optional, callable used to print each resource header
 - `table_print` - optional, callable used to print the table data
-- `max_cell_size` - optional, limit the maximum cell size to the given number of bytes, the underlying tabulate library cannot handle large data sizes
+- `max_cell_size` - optional, limit the maximum cell size to the given number of chars
 - `**tabulate_kwargs` - additional kwargs passed to [tabulate](https://bitbucket.org/astanin/python-tabulate), allows to customize the printed tables
 
 If you are running from a [Jupyter](https://jupyter.org/) notebook, add `tablefmt='html'` to render an html table:

--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -63,7 +63,8 @@ Just prints whatever it sees. Good for debugging.
 
 ```python
 def printer(num_rows=10, last_rows=None, fields=None, resources=None,
-            header_print=_header_print, table_print=_table_print, **tabulate_kwargs):
+            header_print=_header_print, table_print=_table_print,
+            max_cell_size=100, **tabulate_kwargs):
     pass
 ```
 
@@ -73,6 +74,7 @@ def printer(num_rows=10, last_rows=None, fields=None, resources=None,
 - `resources` - optional, allows to limit the printed resources, same semantics as `load` processor `resources` argument
 - `header_print` - optional, callable used to print each resource header
 - `table_print` - optional, callable used to print the table data
+- `max_cell_size` - optional, limit the maximum cell size to the given number of bytes, the underlying tabulate library cannot handle large data sizes
 - `**tabulate_kwargs` - additional kwargs passed to [tabulate](https://bitbucket.org/astanin/python-tabulate), allows to customize the printed tables
 
 If you are running from a [Jupyter](https://jupyter.org/) notebook, add `tablefmt='html'` to render an html table:

--- a/dataflows/processors/printer.py
+++ b/dataflows/processors/printer.py
@@ -1,4 +1,3 @@
-import sys
 from tabulate import tabulate
 from ..helpers.resource_matcher import ResourceMatcher
 

--- a/dataflows/processors/printer.py
+++ b/dataflows/processors/printer.py
@@ -1,3 +1,4 @@
+import sys
 from tabulate import tabulate
 from ..helpers.resource_matcher import ResourceMatcher
 
@@ -26,8 +27,15 @@ def _table_print(data, kwargs):
         print(data)
 
 
+def truncate_cell(value, max_size):
+    if sys.getsizeof(value) > max_size:
+        return str(value)[:max_size] + ' ...'
+    else:
+        return value
+
+
 def printer(num_rows=10, last_rows=None, fields=None, resources=None,
-            header_print=_header_print, table_print=_table_print, **kwargs):
+            header_print=_header_print, table_print=_table_print, max_cell_size=100, **kwargs):
 
     def func(rows):
         spec = rows.res
@@ -54,7 +62,7 @@ def printer(num_rows=10, last_rows=None, fields=None, resources=None,
             yield row
 
             index = i + 1
-            row = [index] + [row[f] for f in field_names]
+            row = [index] + [truncate_cell(row[f], max_cell_size) for f in field_names]
 
             if index - x == (num_rows + 1):
                 x *= num_rows

--- a/dataflows/processors/printer.py
+++ b/dataflows/processors/printer.py
@@ -28,8 +28,9 @@ def _table_print(data, kwargs):
 
 
 def truncate_cell(value, max_size):
-    if sys.getsizeof(value) > max_size:
-        return str(value)[:max_size] + ' ...'
+    value = str(value)
+    if max_size is not None and len(value) > max_size:
+        return value[:max_size] + ' ...'
     else:
         return value
 


### PR DESCRIPTION
the tabulate module used by the printer processor crashes for large cell sizes

this limits the maximum cell size and truncates the cell

also better for aesthetic reasons