### PR TITLE
Fix outdated parameter names in `filter_rows` ref

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -401,7 +401,7 @@ def unpivot(unpivot_fields, extra_keys, extra_value, resources=None):
   - The index of the resource in the package
 
 
-#### filter_rows.py
+#### filter_rows
 Filter rows based on inclusive and exclusive value filters.
 `filter_rows` accepts equality and inequality conditions and tests each row in the selected resources. If none of the conditions validate, the row will be discarded.
 
@@ -410,8 +410,8 @@ def filter_rows(equals=tuple(), not_equals=tuple(), resources=None):
     pass
 ```
 
-- `in` - Mapping of keys to values which translate to `row[key] == value` conditions
-- `out` - Mapping of keys to values which translate to `row[key] != value` conditions
+- `equals` - Mapping of keys to values which translate to `row[key] == value` conditions
+- `not_equals` - Mapping of keys to values which translate to `row[key] != value` conditions
 - `resources`
   - A name of a resource to operate on
   - A regular expression matching resource names
@@ -419,7 +419,7 @@ def filter_rows(equals=tuple(), not_equals=tuple(), resources=None):
   - `None` indicates operation should be done on all resources
   - The index of the resource in the package
 
-Both `in` and `out` should be a list of dicts.
+Both `equals` and `not_equals` should be a list of dicts.
 
 ### Manipulate package
 #### update_package.py


### PR DESCRIPTION
Seems like parameter names were changed in the signature but not updated in the detailed description.