### PR TITLE
Add load infer, cast and error strategies

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -39,7 +39,9 @@ DataFlows comes with a few built-in processors which do most of the heavy liftin
 Loads data from various source types (local files, remote URLS, Google Spreadsheets, databases...)
 
 ```python
-def load(source, name=None, resources=None, validate=False, strip=True, force_strings=False, limit_rows=None, **options):
+def load(source, name=None, resources=None, strip=True, limit_rows=None,
+         infer_strategy=None, cast_strategy=None, on_error=raise_exception,
+         **options)
     pass
 ```
 
@@ -60,10 +62,26 @@ def load(source, name=None, resources=None, validate=False, strip=True, force_st
 - `options` - based on the loaded file, extra options (e.g. `sheet` for Excel files etc., see the link to tabulator above)
 
 Relevant only when _not_ loading data from a datapackage:
-- `force_strings` - Don't infer data types, assume everything is a string.
-- `validate` - Attempt to cast data to the inferred data-types.
 - `strip` - Should string values be stripped from whitespace characters surrounding them.
 - `limit_rows` - If provided, will limit the number of rows fetched from the source. Takes an integer value which specifies how many rows of the source to stream.
+- `infer_strategy` - Dictates if and how `load` will try to guess the datatypes in the source data:
+    - `load.INFER_STRINGS` - All columns will get a `string` datatype
+    - `load.INFER_PYTHON_TYPES` - All columns will get a datatype matching their python type
+    - `load.INFER_FULL` - All columns will get a datatype matching their python type, except strings which will be attempted to be parsed (e.g `"1" -> 1` etc.) (default)
+- `cast_strategy` - Dictates if and how `load` will parse and validate the data against the datatypes in the inferred schema:
+    - `load.CAST_TO_STRINGS` - All data will be casted to strings (regardless of how it's stored in the source file) and won't be validated using the schema.
+    - `load.CAST_DO_NOTHING` - Data will be passed as-is without modifications or validation
+    - `load.CAST_WITH_SCHEMA` - Data will be parsed and casted using the schema and will error in case of faulty data
+- `on_error` - Dictates how `load` will behave in case of a validation error.
+    Options are identical to `on_error` in `set_type` and `validate`
+
+
+Some deprecated options:
+- `force_strings` - Don't infer data types, assume everything is a string.
+    (equivalent to `infer_strategy = INFER_STRINGS, cast_strategy = CAST_TO_STRINGS`)
+- `validate` - Attempt to cast data to the inferred data-types.
+    (equivalent to `cast_strategy = CAST_WITH_SCHEMA, on_error = raise_exception`)
+
 
 #### printer
 Just prints whatever it sees. Good for debugging.

--- a/data/beatles_age.csv
+++ b/data/beatles_age.csv
@@ -1,0 +1,5 @@
+name,age
+john,18
+paul,16
+george,17
+ringo,22

--- a/data/beatles_age.json
+++ b/data/beatles_age.json
@@ -1,0 +1,6 @@
+[
+    {"name": "john", "age": 18},
+    {"name": "paul", "age": 16},
+    {"name": "george", "age": 17},
+    {"name": "ringo", "age": 22}
+]

--- a/dataflows/base/schema_validator.py
+++ b/dataflows/base/schema_validator.py
@@ -37,6 +37,7 @@ def schema_validator(resource, iterator,
     if isinstance(resource, Resource):
         schema: Schema = resource.schema
         assert schema is not None
+        resource = resource.descriptor
     else:
         schema: Schema = Schema(resource.get('schema', {}))
     if field_names is None:
@@ -47,7 +48,7 @@ def schema_validator(resource, iterator,
             for f in schema_fields:
                 row[f.name] = f.cast_value(row.get(f.name))
         except CastError as e:
-            if not on_error(resource.name, row, i, e):
+            if not on_error(resource['name'], row, i, e):
                 continue
 
         yield row

--- a/dataflows/processors/dumpers/dumper_base.py
+++ b/dataflows/processors/dumpers/dumper_base.py
@@ -18,6 +18,7 @@ class DumperBase(DataStreamProcessor):
         self.resource_hash = counters.get('resource-hash', 'hash')
         self.add_filehash_to_path = options.get('add_filehash_to_path', False)
         self.pretty_descriptor = options.get('pretty_descriptor', True)
+        self.schema_validator_options = options.get('validator_options', {})
 
     @staticmethod
     def get_attr(obj, prop, default=None):
@@ -81,7 +82,8 @@ class DumperBase(DataStreamProcessor):
             ret = self.process_resource(
                         ResourceWrapper(
                             resource.res,
-                            schema_validator(resource.res, resource)
+                            schema_validator(resource.res, resource,
+                                             **self.schema_validator_options)
                         )
             )
             ret = self.row_counter(resource, ret)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ PACKAGE = 'dataflows'
 NAME = PACKAGE.replace('_', '-')
 INSTALL_REQUIRES = [
     'datapackage>=1.5.0',
+    'tableschema>=1.5',
     'kvfile>=0.0.6',
     'click',
     'jinja2',


### PR DESCRIPTION
This PR generalizes the way that `load` infers and casts data types, deprecating the `validate` and `force_strings` arguments into three 'strategy' arguments: `infer_strategy`, `cast_strategy` and `on_error` (to decide what to do when validations errors occur).

See here for usage:
https://github.com/datahq/dataflows/pull/88/files#diff-0edecdf275b79739bdb4ca088cfb67e5R67
