### PR TITLE
Added regex parameter for set_type

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -390,7 +390,7 @@ Sets a field's data type and type options and validates its data based on its ne
 By default, this processor modifies the last resource in the package.
 
 ```python
-def set_type(name, resources=-1, on_error=None, **options):
+def set_type(name, resources=-1, regex=True, on_error=None, **options):
     pass
 ```
 
@@ -401,6 +401,7 @@ def set_type(name, resources=-1, on_error=None, **options):
   - A list of resource names
   - `None` indicates operation should be done on all resources
   - The index of the resource in the package
+- `regex` - if set to `False` field names will be interpreted as strings not as regular expressions (`True` by default)
 - `on_error` - callback function to be called when a validation error occurs.
   Function has the signature `callback(resource_name, row, row_index, exception)`.
   It could raise an exception, or return `True` (for keeping the row anyway) or `False` (for dropping it).

--- a/data/regex.csv
+++ b/data/regex.csv
@@ -1,0 +1,4 @@
+city,temperature (24h)
+london,23
+paris,26
+rome,21

--- a/dataflows/processors/set_type.py
+++ b/dataflows/processors/set_type.py
@@ -6,7 +6,7 @@ from .. import DataStreamProcessor, schema_validator
 
 class set_type(DataStreamProcessor):
 
-    def __init__(self, name, regex=True, resources=-1, on_error=None, **options):
+    def __init__(self, name, resources=-1, regex=True, on_error=None, **options):
         super(set_type, self).__init__()
         if not regex:
             name = re.escape(name)

--- a/dataflows/processors/set_type.py
+++ b/dataflows/processors/set_type.py
@@ -6,8 +6,10 @@ from .. import DataStreamProcessor, schema_validator
 
 class set_type(DataStreamProcessor):
 
-    def __init__(self, name, resources=-1, on_error=None, **options):
+    def __init__(self, name, regex=True, resources=-1, on_error=None, **options):
         super(set_type, self).__init__()
+        if not regex:
+            name = re.escape(name)
         self.name = re.compile(f'^{name}$')
         self.options = options
         self.resources = resources

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1127,3 +1127,18 @@ def test_load_limit_rows():
         {'name': 'paul', 'instrument': 'bass'},
         {'name': 'george', 'instrument': 'guitar'},
     ]]
+
+
+def test_set_type_regex():
+    from dataflows import load, set_type
+    flow = Flow(
+        load('data/regex.csv'),
+        set_type('city', type='string'),
+        set_type('temperature (24h)', type='integer', regex=False),
+    )
+    data = flow.results()[0]
+    assert data == [[
+        {'city': 'london', 'temperature (24h)': 23},
+        {'city': 'paris', 'temperature (24h)': 26},
+        {'city': 'rome', 'temperature (24h)': 21},
+    ]]


### PR DESCRIPTION
@akariv 
Here is an issue with field names interpreted as regex - https://github.com/BCODMO/frictionless-usecases/issues/9

What do you think of adding a parameter `regex/use_regex/disable_regex/exact_value/?` (not sure about naming) set to `true` by default or something like this to add an ability to disabling as regex interpretation?

It's WIP if it makes sense I'll add tests/docs and a dpp update.

---

It works for me using e.g. this example:

```yml

  - run: set_types
    parameters:
        resources: data
        regex: false
        types:
          temperature (24h):
              type: integer
```