### PR TITLE
Implement full outer join

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -657,7 +657,7 @@ A special case for the join operation is when there is no target stream, and all
 This mode is called _deduplication_ mode - The target resource will be created and de-duplicated rows from the source will be added to it.
 
 ```python
-def join(source_name, source_key, target_name, target_key, fields={}, full=True, source_delete=True):
+def join(source_name, source_key, target_name, target_key, fields={}, mode='half-outer', source_delete=True):
     pass
 
 def join_with_self(resource_name, join_key, fields):
@@ -715,7 +715,11 @@ def join_with_self(resource_name, join_key, fields):
     By default, `aggregate` takes the `any` value.
 
   If neither `name` or `aggregate` need to be specified, the mapping can map to the empty object `{}` or to `null`.
-- `full` - Boolean,
+- `mode` - Enum,
+  - if `inner`, failed lookups in the source will result in dropping the row from the target. It uses the same principle as the SQL's inner join.
+  - If `half-outer` (the default), failed lookups in the source will result in "null" values at the source. It uses the same principle as the SQL's left/right outer join.
+  - if `full-outer`, failed lookups in the source will result in "null" values at the source. All not used values from the target will result in "null" values at the source. It uses the same principle as the SQL's full outer join.
+- `full` - Boolean [DEPRECATED - use `mode`],
   - If `True` (the default), failed lookups in the source will result in "null" values at the source.
   - if `False`, failed lookups in the source will result in dropping the row from the target.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -73,7 +73,7 @@ We can load data from a file instead:
 
 ```python
 %%writefile beatles.csv
-name,instrument 
+name,instrument
 john,guitar
 paul,bass
 george,guitar
@@ -215,7 +215,7 @@ Flow(
 
 Data is automatically converted to the correct native Python type.
 
-Apart from data-types, it's also possible to set other constraints to the data. If the data fails validation (or does not fit the assigned data-type) an exception will be thrown - making this method highly effective for validating data and ensuring data quality. 
+Apart from data-types, it's also possible to set other constraints to the data. If the data fails validation (or does not fit the assigned data-type) an exception will be thrown - making this method highly effective for validating data and ensuring data quality.
 
 What about large data files? In the above examples, the results are loaded into memory, which is not always preferrable or acceptable. In many cases, we'd like to store the results directly onto a hard drive - without having the machine's RAM limit in any way the amount of data we can process.
 
@@ -334,9 +334,9 @@ Flow(
 
 
 
-The `filter_pythagorean_triplets` function takes an iterator of rows, and yields only the ones that pass its condition. 
+The `filter_pythagorean_triplets` function takes an iterator of rows, and yields only the ones that pass its condition.
 
-The flow framework knows whether a function is meant to hande a single row or a row iterator based on its parameters: 
+The flow framework knows whether a function is meant to hande a single row or a row iterator based on its parameters:
 
 - if it accepts a single `row` parameter, then it's a row processor.
 - if it accepts a single `rows` parameter, then it's a rows processor.
@@ -491,7 +491,7 @@ from dataflows import Flow, load, dump_to_path, checkpoint, printer
 
 def find_double_winners(package):
 
-    # Remove the emmies resource - 
+    # Remove the emmies resource -
     #    we're going to consume it now
     package.pkg.remove_resource('emmies')
     # Must yield the modified datapackage
@@ -500,22 +500,22 @@ def find_double_winners(package):
     # Now iterate on all resources
     resources = iter(package)
 
-    # Emmies is the first - 
+    # Emmies is the first -
     # read all its data and create a set of winner names
     emmy = next(resources)
     emmy_winners = set(
-        map(lambda x: x['nominee'], 
+        map(lambda x: x['nominee'],
             filter(lambda x: x['winner'],
                    emmy))
     )
 
-    # Oscars are next - 
+    # Oscars are next -
     # filter rows based on the emmy winner set
     academy = next(resources)
-    yield filter(lambda row: (row['Winner'] and 
+    yield filter(lambda row: (row['Winner'] and
                               row['Name'] in emmy_winners),
                  academy)
-    
+
     # important to deque generators to ensure finalization steps of previous processors are executed
     yield from resources
 
@@ -590,7 +590,7 @@ Flow(
     join(
         'emmies_filtered', ['emmy_nominee'],  # Source resource
         'oscars', ['Name'],                   # Target resource
-        full=False   # Don't add new fields, remove unmatched rows
+        mode='inner'   # Don't add new fields, remove unmatched rows
     ),
     filter_rows(equals=[dict(Winner='1')]),
     dump_to_path('double_winners'),
@@ -656,14 +656,14 @@ def text_processing_flow(star_letter_idx):
     def upper(row):
         for k in row:
             row[k] = row[k].upper()
-    
+
     # star the letter at the index from star_letter_idx argument
     def star_letter(row):
         for k in row:
             s = list(row[k])
             s[star_letter_idx] = '*'
             row[k] = ''.join(s)
-    
+
     def print_foo(row):
         print('  '.join(list(row['foo'])))
 

--- a/data/cities.csv
+++ b/data/cities.csv
@@ -1,0 +1,4 @@
+id,city
+1,london
+2,paris
+3,rome

--- a/data/population.csv
+++ b/data/population.csv
@@ -1,0 +1,4 @@
+id,population
+1,8
+2,2
+4,3

--- a/dataflows/processors/join.py
+++ b/dataflows/processors/join.py
@@ -355,11 +355,11 @@ def join(source_name, source_key, target_name, target_key, fields={}, full=True,
 
 
 def join_with_self(resource_name, join_key, fields):
-    return join_aux(resource_name, join_key, True, resource_name, None, fields, True)
+    return join_aux(resource_name, join_key, True, resource_name, None, fields, True, None)
 
 
 def join_self(source_name, source_key, target_name, fields):
     import warnings
     warnings.warn('join_self is being deprecated, use join_with_self instead',
                   DeprecationWarning)
-    return join_aux(source_name, source_key, True, target_name, None, fields, True)
+    return join_aux(source_name, source_key, True, target_name, None, fields, True, None)

--- a/dataflows/processors/join.py
+++ b/dataflows/processors/join.py
@@ -1,6 +1,7 @@
 import re
 import copy
 import os
+import warnings
 import collections
 
 from kvfile import KVFile
@@ -171,8 +172,12 @@ def join_aux(source_name, source_key, source_delete,  # noqa: C901
     db_keys_usage = KVFile()
     db = KVFile()
 
-    # Joining mode
-    if mode is None:
+    # Mode of join operation
+    if full is not None:
+        warnings.warn(
+            'For the `join` processor the `full=True` flag is deprecated. '
+            'Please use the "mode" parameter instead.',
+            UserWarning)
         mode = 'half-outer' if full else 'inner'
     assert mode in ['inner', 'half-outer', 'full-outer']
 
@@ -354,7 +359,7 @@ def join_aux(source_name, source_key, source_delete,  # noqa: C901
     return func
 
 
-def join(source_name, source_key, target_name, target_key, fields={}, full=True, mode=None, source_delete=True):
+def join(source_name, source_key, target_name, target_key, fields={}, full=None, mode='half-outer', source_delete=True):
     return join_aux(source_name, source_key, source_delete, target_name, target_key, fields, full, mode)
 
 

--- a/dataflows/processors/join.py
+++ b/dataflows/processors/join.py
@@ -2,7 +2,6 @@ import re
 import copy
 import os
 import collections
-import logging
 
 from kvfile import KVFile
 
@@ -243,7 +242,6 @@ def join_aux(source_name, source_key, source_delete,  # noqa: C901
                         if k in fields
                     ))
                     yield extra
-
 
     # Yields the new resources
     def new_resource_iterator(resource_iterator):

--- a/dataflows/processors/join.py
+++ b/dataflows/processors/join.py
@@ -226,11 +226,12 @@ def join_aux(source_name, source_key, source_delete,  # noqa: C901
                     )
                     del db_keys[key]
                 except KeyError:
-                    if mode != 'inner':
-                        extra = dict(
-                            (k, row.get(k))
-                            for k in fields.keys()
-                        )
+                    if mode == 'inner':
+                        continue
+                    extra = dict(
+                        (k, row.get(k))
+                        for k in fields.keys()
+                    )
                 row.update(extra)
                 yield row
             if mode == 'full-outer':

--- a/dataflows/processors/join.py
+++ b/dataflows/processors/join.py
@@ -218,12 +218,7 @@ def join_aux(source_name, source_key, source_delete,  # noqa: C901
             for row in resource:
                 key = target_key(row)
                 try:
-                    extra = db.get(key)
-                    extra = dict(
-                        (k, AGGREGATORS[fields[k]['aggregate']].finaliser(v))
-                        for k, v in extra.items()
-                        if k in fields
-                    )
+                    extra = create_extra_by_key(key)
                     del db_keys[key]
                 except KeyError:
                     if mode == 'inner':
@@ -236,13 +231,18 @@ def join_aux(source_name, source_key, source_delete,  # noqa: C901
                 yield row
             if mode == 'full-outer':
                 for key in db_keys:
-                    extra = db.get(key)
-                    extra.update(dict(
-                        (k, AGGREGATORS[fields[k]['aggregate']].finaliser(v))
-                        for k, v in extra.items()
-                        if k in fields
-                    ))
+                    extra = create_extra_by_key(key)
                     yield extra
+
+    # Creates extra by key
+    def create_extra_by_key(key):
+        extra = db.get(key)
+        extra.update(dict(
+            (k, AGGREGATORS[fields[k]['aggregate']].finaliser(v))
+            for k, v in extra.items()
+            if k in fields
+        ))
+        return extra
 
     # Yields the new resources
     def new_resource_iterator(resource_iterator):

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1161,3 +1161,26 @@ def test_set_type_regex():
         {'city': 'paris', 'temperature (24h)': 26},
         {'city': 'rome', 'temperature (24h)': 21},
     ]]
+
+
+def test_join_full_outer():
+    from dataflows import load, set_type, join
+    flow = Flow(
+        load('data/population.csv'),
+        load('data/cities.csv'),
+        join(
+            source_name='population',
+            source_key=['id'],
+            target_name='cities',
+            target_key=['id'],
+            fields={'population': {'name': 'population'}},
+            mode='full-outer',
+        ),
+    )
+    data = flow.results()[0]
+    assert data == [[
+        {'id': 1, 'city': 'london', 'population': 8},
+        {'id': 2, 'city': 'paris', 'population': 2},
+        {'id': 3, 'city': 'rome', 'population': None},
+        {'id': 4, 'city': None, 'population': 3},
+    ]]

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1059,7 +1059,7 @@ def test_join():
                     'name': 'last_name',
                     'aggregate': 'counters'
                 }
-            ), False, True
+            ), full=False, source_delete=True
         )
     ).results()
 


### PR DESCRIPTION
Hi @akariv,

It's a first attempt to implement full outer join mode as asked here https://github.com/BCODMO/frictionless-usecases/issues/12

If adding this functionality makes sense there are a few questions:
- user interface: for now, added additional overriding `mode` parameter (`inner/half-outer/full-outer`) because the `full` flag can't cover all the options and slightly contradict to the SQL terminology
- effectiveness of the `db_keys` cache. Not sure will it be good enough using memory for DPP
- I don't see it's possible to join without aggregation as SQL does by default. I'm curious whether it makes sense to add it in the future
- other flaws in the implementation? 

Please take a look