### PR TITLE
Added regex parameter for delete_fields

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -296,7 +296,7 @@ Delete fields (columns) from streamed resources
 _Note: if multiple resources provided, all of them should contain all fields to delete_
 
 ```python
-def delete_fields(fields, resources=None):
+def delete_fields(fields, resources=None, regex=True):
     pass
 ```
 
@@ -307,6 +307,7 @@ def delete_fields(fields, resources=None):
   - A list of resource names
   - `None` indicates operation should be done on all resources
   - The index of the resource in the package
+- `regex` - if set to `False` field names will be interpreted as strings not as regular expressions (`True` by default)
 
 #### add_computed_field
 Adds new fields whose values are based on existing columns.

--- a/dataflows/processors/delete_fields.py
+++ b/dataflows/processors/delete_fields.py
@@ -12,13 +12,13 @@ def process_resource(rows, fields):
         )
 
 
-def delete_fields(fields, resources=None):
+def delete_fields(fields, resources=None, regex=True):
 
     def func(package):
         matcher = ResourceMatcher(resources, package.pkg)
         dp_resources = package.pkg.descriptor.get('resources', [])
         field_res = [
-            re.compile('^{}$'.format(f)) for f in fields
+            re.compile('^{}$'.format(f if regex else re.escape(f))) for f in fields
         ]
         matched = set()
         new_field_names = {}

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1161,3 +1161,17 @@ def test_set_type_regex():
         {'city': 'paris', 'temperature (24h)': 26},
         {'city': 'rome', 'temperature (24h)': 21},
     ]]
+
+
+def test_delete_fields_regex():
+    from dataflows import load, delete_fields
+    flow = Flow(
+        load('data/regex.csv'),
+        delete_fields(['temperature (24h)'], regex=False),
+    )
+    data = flow.results()[0]
+    assert data == [[
+        {'city': 'london'},
+        {'city': 'paris'},
+        {'city': 'rome'},
+    ]]


### PR DESCRIPTION
It's the same as we did for `set_types` - https://github.com/datahq/dataflows/pull/89

Related issue - https://github.com/BCODMO/frictionless-usecases/issues/16