### PR TITLE
Added `override_schema/fields` to the `load` processor

### DIFF
--- a/PROCESSORS.md
+++ b/PROCESSORS.md
@@ -40,7 +40,9 @@ Loads data from various source types (local files, remote URLS, Google Spreadshe
 
 ```python
 def load(source, name=None, resources=None, strip=True, limit_rows=None,
-         infer_strategy=None, cast_strategy=None, on_error=raise_exception,
+         infer_strategy=None, cast_strategy=None,
+         override_schema=None, override_fields=None,
+         on_error=raise_exception,
          **options)
     pass
 ```
@@ -72,6 +74,8 @@ Relevant only when _not_ loading data from a datapackage:
     - `load.CAST_TO_STRINGS` - All data will be casted to strings (regardless of how it's stored in the source file) and won't be validated using the schema.
     - `load.CAST_DO_NOTHING` - Data will be passed as-is without modifications or validation
     - `load.CAST_WITH_SCHEMA` - Data will be parsed and casted using the schema and will error in case of faulty data
+- `override_schema` - Provided dictionary will be merged into the inferred schema. If `fields` key is set its contents will fully replace the inferred fields array. The same behavior will be applied for all other nested structures.
+- `override_fields` - Provided mapping will patch the inferred `schema.fields` array. In the mapping keys must be field names and values must be dictionaries intended to be merged into the corresponding field's metadata.
 - `on_error` - Dictates how `load` will behave in case of a validation error.
     Options are identical to `on_error` in `set_type` and `validate`
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1161,3 +1161,78 @@ def test_set_type_regex():
         {'city': 'paris', 'temperature (24h)': 26},
         {'city': 'rome', 'temperature (24h)': 21},
     ]]
+
+
+def test_load_override_schema():
+    from dataflows import load
+    flow = Flow(
+        load('data/beatles_age.csv',
+            override_schema={
+                'title': 'title',
+                'missingValues': ['ringo'],
+            }
+        ),
+    )
+    data, package, stats = flow.results()
+    assert package.descriptor == {
+        'profile': 'data-package',
+        'resources': [{
+            'format': 'csv',
+            'name': 'beatles_age',
+            'path': 'beatles_age.csv',
+            'profile': 'tabular-data-resource',
+            'schema': {
+                'fields': [
+                    {'format': 'default', 'name': 'name', 'type': 'string'},
+                    {'format': 'default', 'name': 'age', 'type': 'integer'}
+                ],
+                'missingValues': ['ringo'],
+                'title': 'title'
+            }
+        }]
+    }
+    assert data == [[
+        {'name': 'john', 'age': 18},
+        {'name': 'paul', 'age': 16},
+        {'name': 'george', 'age': 17},
+        {'name': None, 'age': 22},
+    ]]
+
+
+def test_load_override_schema_and_fields():
+    from dataflows import load
+    flow = Flow(
+        load('data/beatles_age.csv',
+            override_schema={
+                'title': 'title',
+                'missingValues': ['ringo'],
+            },
+            override_fields={
+                'age': {'type': 'string'},
+            }
+        ),
+    )
+    data, package, stats = flow.results()
+    assert package.descriptor == {
+        'profile': 'data-package',
+        'resources': [{
+            'format': 'csv',
+            'name': 'beatles_age',
+            'path': 'beatles_age.csv',
+            'profile': 'tabular-data-resource',
+            'schema': {
+                'fields': [
+                    {'format': 'default', 'name': 'name', 'type': 'string'},
+                    {'format': 'default', 'name': 'age', 'type': 'string'}
+                ],
+                'missingValues': ['ringo'],
+                'title': 'title',
+            }
+        }]
+    }
+    assert data == [[
+        {'name': 'john', 'age': '18'},
+        {'name': 'paul', 'age': '16'},
+        {'name': 'george', 'age': '17'},
+        {'name': None, 'age': '22'},
+    ]]


### PR DESCRIPTION
@akariv 
Please take a look. It's an initial try to implement this one - https://github.com/BCODMO/frictionless-usecases/issues/6#issuecomment-496394992

I'm not sure what the best naming solution:
- current `override_schema/fields`
- just `schema/fields`
- some combined `schema` (could be confusing though)

PS.
It seems we don't need to add anything to DPP to propagate this change - https://github.com/frictionlessdata/datapackage-pipelines/blob/master/datapackage_pipelines/lib/load.py