### PR TITLE
Adds instructions for minimal OS systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Read more in the [Features section below](#features).
 
 Install `dataflows` via `pip install.`
 
+(If you are using minimal UNIX OS, run first `sudo apt install build-essential`)
+
 Then use the command-line interface to bootstrap a basic processing script for any remote data file:
 
 ```bash


### PR DESCRIPTION
Adds `sudo apt install build-essential` to the instructions.

The dataflow package contains C packages that are needed in the OS, if not present the installation crashes.