### PR TITLE
Force strings from stream for the infer strings strategy

### DIFF
--- a/dataflows/processors/load.py
+++ b/dataflows/processors/load.py
@@ -140,6 +140,10 @@ class load(DataStreamProcessor):
             if options['validate']:
                 cast_strategy = self.CAST_WITH_SCHEMA
 
+        # Force strings from stream for the INFER_STRINGS strategy
+        if infer_strategy == self.INFER_STRINGS:
+            self.options['force_strings'] = True
+
         self.guesser = {
             self.INFER_FULL: None,
             self.INFER_PYTHON_TYPES: TypesGuesser,

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -623,6 +623,24 @@ def test_load_strategies():
     }
 
 
+def test_load_strategy_infer_strings_from_native_types():
+    from dataflows import load
+
+    flow = Flow(
+        load(
+            'data/beatles_age.json',
+            infer_strategy='strings',
+        ),
+    )
+    data, package, stats = flow.results()
+    assert data == [[
+        {'age': '18', 'name': 'john'},
+        {'age': '16', 'name': 'paul'},
+        {'age': '17', 'name': 'george'},
+        {'age': '22', 'name': 'ringo'},
+    ]]
+
+
 def test_load_name_path():
     from dataflows import load
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -617,8 +617,8 @@ def test_load_strategies():
         'pytypes nothing': out_t + out_s,
         'pytypes schema': out_t + out_s,
         'pytypes strings': out_s + out_s,
-        'strings nothing': out_t + out_s,
-        'strings schema': [] + out_s,
+        'strings nothing': out_s + out_s,
+        'strings schema': out_s + out_s,
         'strings strings': out_s + out_s
     }
 


### PR DESCRIPTION
- fixes https://github.com/BCODMO/frictionless-usecases/issues/27

---

@akariv 
Without this change in the `load` processor, the added test fails which doesn't seem the correct behavior. I also had to update the strategies test. Please take a look at the issue above for more info about where it popped up.

WDYT?