### PR TITLE
Make FileFormat respect missing values

### DIFF
--- a/dataflows/helpers/iterable_loader.py
+++ b/dataflows/helpers/iterable_loader.py
@@ -29,12 +29,12 @@ class iterable_storage(Storage):
         for value in values:
             if isinstance(value, str):
                 types.add('string')
+            elif isinstance(value, bool):
+                types.add('boolean')
             elif isinstance(value, int):
                 types.add('integer')
             elif isinstance(value, (float, decimal.Decimal)):
                 types.add('number')
-            elif isinstance(value, bool):
-                types.add('boolean')
             elif isinstance(value, list):
                 types.add('array')
             elif isinstance(value, dict):

--- a/dataflows/processors/dumpers/file_formats.py
+++ b/dataflows/processors/dumpers/file_formats.py
@@ -61,10 +61,12 @@ class FileFormat():
             raise
 
     def __transform_value(self, value, field):
-        # The second condition supports a `tableschema`'s mode of perserving missing values
-        # https://github.com/frictionlessdata/tableschema-py#experimental
-        if value is None or value in self.missing_values:
+        if value is None:
             return self.NULL_VALUE
+        # It supports a `tableschema`'s mode of perserving missing values
+        # https://github.com/frictionlessdata/tableschema-py#experimental
+        if value in self.missing_values:
+            return value
         return field.descriptor['serializer'](value)
 
     def write_transformed_row(self, *_):

--- a/dataflows/processors/dumpers/file_formats.py
+++ b/dataflows/processors/dumpers/file_formats.py
@@ -34,6 +34,7 @@ class FileFormat():
         self.headers = [f.name for f in schema.fields]
         self.fields = dict((f.name, f) for f in schema.fields)
         self.temporal_format_property = temporal_format_property
+        self.missing_values = schema.descriptor.get('missingValues', [])
 
         # Set fields' serializers
         for field in schema.fields:
@@ -60,7 +61,9 @@ class FileFormat():
             raise
 
     def __transform_value(self, value, field):
-        if value is None:
+        # The second condition supports a `tableschema`'s mode of perserving missing values
+        # https://github.com/frictionlessdata/tableschema-py#experimental
+        if value is None or value in self.missing_values:
             return self.NULL_VALUE
         return field.descriptor['serializer'](value)
 


### PR DESCRIPTION
- connects https://github.com/frictionlessdata/datapackage-pipelines/issues/177

---

It's a small change to help `tableschema`'s preserve missing values mode work with `dataflows` - https://github.com/frictionlessdata/tableschema-py#experimental