### PR TITLE
In join preserve source fields order if possible

### DIFF
--- a/data/cities_metadata.csv
+++ b/data/cities_metadata.csv
@@ -1,0 +1,4 @@
+id,key2,key1
+1,val2,val1
+2,val2,val1
+3,val2,val1

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1536,9 +1536,9 @@ def test_join_preserve_source_fields_order():
         {'name': 'key1', 'type': 'string', 'format': 'default'}
     ]
     assert data == [[
-        {'id': 1, 'name': 'london', 'key1': 'val1', 'key2': 'val2'},
-        {'id': 2, 'name': 'paris', 'key1': 'val1', 'key2': 'val2'},
-        {'id': 3, 'name': 'rome', 'key1': 'val1', 'key2': 'val2'},
+        {'id': 1, 'city': 'london', 'key1': 'val1', 'key2': 'val2'},
+        {'id': 2, 'city': 'paris', 'key1': 'val1', 'key2': 'val2'},
+        {'id': 3, 'city': 'rome', 'key1': 'val1', 'key2': 'val2'},
     ]]
 
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1515,6 +1515,33 @@ def test_join_row_number_format_string():
     ]]
 
 
+def test_join_preserve_source_fields_order():
+    from dataflows import load, join
+    flow = Flow(
+        load('data/cities_metadata.csv'),
+        load('data/cities.csv'),
+        join(
+            source_name='cities_metadata',
+            source_key='{id}',
+            target_name='cities',
+            target_key='{id}',
+            fields={'key1': {'name': 'key1'}, 'key2': {'name': 'key2'}}
+        ),
+    )
+    data, package, stats = flow.results()
+    assert package.descriptor['resources'][0]['schema']['fields'] == [
+        {'name': 'id', 'type': 'integer', 'format': 'default'},
+        {'name': 'city', 'type': 'string', 'format': 'default'},
+        {'name': 'key2', 'type': 'string', 'format': 'default'},
+        {'name': 'key1', 'type': 'string', 'format': 'default'}
+    ]
+    assert data == [[
+        {'id': 1, 'name': 'london', 'key1': 'val1', 'key2': 'val2'},
+        {'id': 2, 'name': 'paris', 'key1': 'val1', 'key2': 'val2'},
+        {'id': 3, 'name': 'rome', 'key1': 'val1', 'key2': 'val2'},
+    ]]
+
+
 def test_load_duplicate_headers():
     from dataflows import load, exceptions
     flow = Flow(

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,6 +1,7 @@
 import pytest
 from dataflows import Flow
 
+
 data = [
     dict(x=1, y='a'),
     dict(x=2, y='b'),


### PR DESCRIPTION
- fixes #140 

---

- If possible, we follow the source field order; if not - doing sorting
- for me, 3 example tests fail both on master and here (can't understand why yet)