### PR TITLE
[WIP] Added collect_errors processor

### DIFF
--- a/dataflows/processors/__init__.py
+++ b/dataflows/processors/__init__.py
@@ -7,6 +7,7 @@ from .dumpers import dump_to_path, dump_to_zip, dump_to_sql
 from .add_computed_field import add_computed_field
 from .add_field import add_field
 from .checkpoint import checkpoint
+from .collect_errors import collect_errors
 from .concatenate import concatenate
 from .conditional import conditional
 from .delete_fields import delete_fields

--- a/dataflows/processors/collect_errors.py
+++ b/dataflows/processors/collect_errors.py
@@ -1,0 +1,39 @@
+from tableschema import Schema
+from tableschema.exceptions import CastError
+from ..helpers.resource_matcher import ResourceMatcher
+from .. import DataStreamProcessor
+
+
+class collect_errors(DataStreamProcessor):
+
+    def __init__(self, schema, resources=-1):
+        super().__init__()
+        self.schema = Schema(schema)
+        self.resources = resources
+
+    def process_resources(self, resources):
+        for res in resources:
+            if self.matcher.match(res.res.name):
+                yield self.collect_errors(res)
+            else:
+                yield res
+
+    def collect_errors(self, resource):
+        errors = []
+        for row in resource:
+            for field in self.schema.fields:
+                try:
+                    field.cast_value(row.get(field.name))
+                except CastError as error:
+                    errors.append(str(error))
+            yield row
+        for descriptor in self.dp.descriptor['resources']:
+            if descriptor.get('name') == resource.res.name:
+                descriptor['errors'] = errors
+        self.dp.commit()
+
+    def process_datapackage(self, dp):
+        dp = super().process_datapackage(dp)
+        self.matcher = ResourceMatcher(self.resources, dp)
+        self.dp = dp
+        return dp

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1820,3 +1820,14 @@ def test_update_stats():
     assert res == [data]
     assert stats == {'a': 1, 'b': 1}
 
+
+def test_collect_errors():
+    from dataflows import load, collect_errors, Flow
+    res, dp, stats = Flow(
+        load('data/cities.csv', name='cities'),
+        collect_errors({'fields': [{'name': 'city', 'constraints': {'maxLength': 4}}]}),
+    ).results()
+    assert dp.get_resource('cities').descriptor.get('errors') == [
+        'Field "city" has constraint "maxLength" which is not satisfied for value "london"',
+        'Field "city" has constraint "maxLength" which is not satisfied for value "paris"'
+    ]


### PR DESCRIPTION
- fixes #142 

---

Hi @cschloer, 

I've checked options for `goodtables` integration and it doesn't seem doable till the end of this stage. So I dove into the initial issue - https://github.com/BCODMO/laminar_web/issues/801 - and tried to implement something simpler. For example, we can have a `collect_errors` processor that works like this:

```
def test_collect_errors():
    from dataflows import load, collect_errors, Flow
    res, dp, stats = Flow(
        load('data/cities.csv', name='cities'),
        # it accepts an "Extra Schema" that can be partial
        collect_errors({'fields': [{'name': 'city', 'constraints': {'maxLength': 4}}]}),
    ).results()
    assert dp.get_resource('cities').descriptor.get('errors') == [
        'Field "city" has constraint "maxLength" which is not satisfied for value "london"',
        'Field "city" has constraint "maxLength" which is not satisfied for value "paris"'
    ]
```

On the other hand, all the checks @adyork had asked can be set in the main `schema` e.g. using `constraints.pattern` - then the validation will fails in dataflows without this processor.