### PR TITLE
Bug with full-outer join, undesired fields, and dumping

### DIFF
--- a/dataflows/processors/join.py
+++ b/dataflows/processors/join.py
@@ -258,11 +258,11 @@ def join_aux(source_name, source_key, source_delete,  # noqa: C901
     # Creates extra by key
     def create_extra_by_key(key):
         extra = db.get(key)
-        extra.update(dict(
+        extra = dict(
             (k, AGGREGATORS[fields[k]['aggregate']].finaliser(v))
             for k, v in extra.items()
             if k in fields
-        ))
+        )
         return extra
 
     # Yields the new resources

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -100,3 +100,30 @@ def test_exception_information_multiple_processors_iterable_error():
     assert str(excinfo.value.cause) == 'custom-iterable-error'
     assert excinfo.value.processor_name == 'iterable_loader'
     assert excinfo.value.processor_position == 1
+
+def test_fullouter_join_dump_different_keys():
+    from dataflows import Flow, join, dump_to_path
+    data1 = [
+        {"col1": 1.531, "col2": "hello"},
+        {"col1": 1.132, "col2": "goodbye"},
+    ]
+    data2 = [
+        {"colA": 1.531, "colB": "123"},
+        {"colA": 1.132, "colB": 1.132},
+    ]
+    f = Flow(
+        data1,
+        data2,
+        join(
+            "res_1",
+            ["col1"],
+            "res_2",
+            ["colA"],
+            {"col2": {"name": "col2", "aggregate": "first"}},
+            mode="full-outer"
+        ),
+        dump_to_path(out_path='out/test_join_dump'),
+    )
+    f.results()
+
+


### PR DESCRIPTION
Hi,

I just found a bug with the `join` processor related to fields from the "source" being added into the target even if they aren't specified. The fields don't make it into the schema, so it can seem fine, but if you run any kind of dump step it errors (because there are unknown fields in the row).

I believe the issue is just that at line 261 of join, the "extra" dict should be set to the filtered dictionary, not updated by it.

Before the fix, the test throws an exception. Afterwards it runs as intended. 

@akariv 