### PR TITLE
Adds noop processor.

### DIFF
--- a/dataflows/processors/noop.py
+++ b/dataflows/processors/noop.py
@@ -1,0 +1,8 @@
+def noop():
+    """Pass through package unchanged."""
+
+    def func(package):
+        yield package.pkg
+        yield from package
+
+    return func

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -2310,3 +2310,24 @@ def test_parallelize():
         parallelize(mult),
     ).results()[0][0][:100]
     print(res)
+
+def test_noop():
+    from dataflows import noop
+
+    datas1 = [
+        {'a': 1, 'b': True, 'c': 'c1'},
+        {'a': 2, 'b': True, 'c': 'c2'},
+    ]
+    datas2 = [
+        {'a': 3, 'b': True, 'c': 'c3'},
+        {'a': 4, 'b': True, 'c': 'c4'},
+        {'a': 5, 'b': True, 'c': 'c5'},
+    ]
+    results, dp, _ = Flow(
+        datas1,
+        datas2,
+        noop,
+    ).results()
+
+    assert results[0] == datas1
+    assert results[1] == datas2


### PR DESCRIPTION
Useful for composing flows as parameterized higher order functions.

Simple example:

```
import data flows as DF


my_data = [...]

def my_great_flow(validate=False):
    return DF.Flow(
        my_data,
        DF.validate() if validate is True else DF.noop()            
    )
```

An alternative approach would be to allow None values in the processor list passed to a flow (`... else None` rather than `... else DF.noop()`), and then filter the list for Nones before running the processors. I don't have a personal preference but perhaps exposing a noop processor is the more explicit approach for consumers of the library.